### PR TITLE
Add OpenAI streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,19 @@ This project is a simple chat application built with React that interacts with t
    npm install
    ```
 2. Provide your OpenAI API key via the `OPENAI_API_KEY` environment variable.
-3. Start the server using `nps` to choose the LLM environment:
+3. (Optional) Set `OLLAMA_MODEL` to change the local model used by Ollama.
+4. Start the server using `nps` to choose the LLM environment:
    ```bash
    npx nps start
    ```
-   You'll be prompted to select **Local** (to use devices via MCP) or **OpenAI**.
-4. Open `http://localhost:3000` in your browser.
+   You'll be prompted to select **Local** (to use devices via MCP), **OpenAI**, or **Ollama**.
+5. Open `http://localhost:3000` in your browser.
+
+## Streaming
+
+Use the **Stream** checkbox in the UI to receive incremental tokens. The server
+exposes a `/api/chat/stream` endpoint that streams responses using
+Server-Sent Events.
 
 ## Testing
 

--- a/openaiClient.js
+++ b/openaiClient.js
@@ -1,5 +1,6 @@
 const OpenAI = require('openai');
 const MCP = require('./mcp');
+const DEFAULT_OLLAMA_MODEL = 'deepseek-r1:7b';
 
 let createClient = () => new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -15,6 +16,20 @@ async function sendMessage(message, devices = []) {
     return mcp.broadcast(message);
   }
 
+  if (env === 'ollama') {
+    const res = await fetch('http://localhost:11434/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL,
+        stream: false,
+        messages: [{ role: 'user', content: message }]
+      })
+    });
+    const data = await res.json();
+    return data.message?.content;
+  }
+
   const openai = createClient();
   const completion = await openai.chat.completions.create({
     model: 'gpt-3.5-turbo',
@@ -23,8 +38,55 @@ async function sendMessage(message, devices = []) {
   return completion.choices[0].message.content;
 }
 
+async function* sendMessageStream(message, devices = []) {
+  if (env === 'local') {
+    const mcp = new MCP(devices);
+    const reply = await mcp.broadcast(message);
+    yield reply.join(', ');
+    return;
+  }
+
+  if (env === 'ollama') {
+    const res = await fetch('http://localhost:11434/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL,
+        stream: true,
+        messages: [{ role: 'user', content: message }]
+      })
+    });
+    const decoder = new TextDecoder();
+    let buffer = '';
+    for await (const chunk of res.body) {
+      buffer += decoder.decode(chunk);
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const data = JSON.parse(trimmed);
+        const token = data.message?.content;
+        if (token) yield token;
+      }
+    }
+    return;
+  }
+
+  const openai = createClient();
+  const stream = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: message }],
+    stream: true
+  });
+  for await (const part of stream) {
+    const token = part.choices[0]?.delta?.content;
+    if (token) yield token;
+  }
+}
+
 function setClientFactory(fn) {
   createClient = fn;
 }
 
-module.exports = { sendMessage, setEnv, setClientFactory };
+module.exports = { sendMessage, sendMessageStream, setEnv, setClientFactory };

--- a/start.js
+++ b/start.js
@@ -7,8 +7,10 @@ function ask(question) {
 }
 
 (async () => {
-  const answer = await ask('Choose environment (1) Local (2) OpenAI: ');
-  const env = /^1|local/i.test(answer) ? 'local' : 'openai';
+  const answer = await ask('Choose environment (1) Local (2) OpenAI (3) Ollama: ');
+  let env = 'openai';
+  if (/^1|local/i.test(answer)) env = 'local';
+  else if (/^3|ollama/i.test(answer)) env = 'ollama';
 
   const child = spawn('node', ['server.js'], {
     stdio: 'inherit',

--- a/test/openaiClient.test.js
+++ b/test/openaiClient.test.js
@@ -6,18 +6,21 @@ const createMock = jest.fn();
 const openaiInstance = { chat: { completions: { create: createMock } } };
 OpenAI.mockImplementation(() => openaiInstance);
 
+global.fetch = jest.fn();
+
 beforeEach(() => {
   createMock.mockReset();
   createMock.mockResolvedValue({
     choices: [{ message: { content: 'unit reply' } }]
   });
+  fetch.mockReset();
 });
 
-let sendMessage, setEnv, setClientFactory;
+let sendMessage, sendMessageStream, setEnv, setClientFactory;
 
 beforeEach(() => {
   jest.resetModules();
-  ({ sendMessage, setEnv, setClientFactory } = require('../openaiClient'));
+  ({ sendMessage, sendMessageStream, setEnv, setClientFactory } = require('../openaiClient'));
   setClientFactory(() => openaiInstance);
 });
 
@@ -45,5 +48,60 @@ test('sendMessage uses MCP when env is local', async () => {
 test('sendMessage throws when openai fails', async () => {
   createMock.mockRejectedValueOnce(new Error('fail'));
   await expect(sendMessage('hi')).rejects.toThrow('fail');
+});
+
+test('sendMessageStream yields tokens', async () => {
+  async function* gen() {
+    yield { choices: [{ delta: { content: 'he' } }] };
+    yield { choices: [{ delta: { content: 'llo' } }] };
+  }
+  createMock.mockResolvedValueOnce(gen());
+  const parts = [];
+  for await (const p of sendMessageStream('hi')) {
+    parts.push(p);
+  }
+  expect(parts.join('')).toBe('hello');
+});
+
+test('sendMessageStream uses MCP when env is local', async () => {
+  setEnv('local');
+  const broadcast = jest.fn().mockResolvedValue(['ok']);
+  jest.doMock('../mcp', () => {
+    return jest.fn().mockImplementation(() => ({ broadcast }));
+  });
+  jest.resetModules();
+  ({ sendMessageStream, setEnv, setClientFactory } = require('../openaiClient'));
+  setClientFactory(() => openaiInstance);
+  setEnv('local');
+  const parts = [];
+  for await (const p of sendMessageStream('hi')) {
+    parts.push(p);
+  }
+  expect(broadcast).toHaveBeenCalledWith('hi');
+  expect(parts.join('')).toBe('ok');
+});
+
+test('sendMessage uses Ollama when env is ollama', async () => {
+  setEnv('ollama');
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ message: { content: 'hey' } }) });
+  const reply = await sendMessage('hi');
+  expect(fetch).toHaveBeenCalled();
+  expect(reply).toBe('hey');
+});
+
+test('sendMessageStream uses Ollama when env is ollama', async () => {
+  setEnv('ollama');
+  const { Readable } = require('stream');
+  const body = Readable.from([
+    Buffer.from(JSON.stringify({ message: { content: 'he' } }) + '\n'),
+    Buffer.from(JSON.stringify({ message: { content: 'llo' } }) + '\n')
+  ]);
+  fetch.mockResolvedValueOnce({ body });
+  const parts = [];
+  for await (const p of sendMessageStream('hi')) {
+    parts.push(p);
+  }
+  expect(fetch).toHaveBeenCalled();
+  expect(parts.join('')).toBe('hello');
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -68,6 +68,23 @@ describe('POST /api/chat', () => {
   });
 });
 
+describe('POST /api/chat/stream', () => {
+  it('streams reply', async () => {
+    async function* gen() {
+      yield { choices: [{ delta: { content: 'a' } }] };
+      yield { choices: [{ delta: { content: 'b' } }] };
+    }
+    createMock.mockResolvedValueOnce(gen());
+    const res = await request(app)
+      .post('/api/chat/stream')
+      .send({ message: 'hi' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+    expect(res.text).toContain('data: a');
+    expect(res.text).toContain('data: b');
+  });
+});
+
 describe('additional routes', () => {
   beforeEach(() => {
     jest.resetModules();


### PR DESCRIPTION
## Summary
- support streaming responses from OpenAI
- expose `/api/chat/stream` server route
- add streaming toggle in the frontend
- document streaming endpoint
- test streaming logic and route
- add optional Ollama backend for local use

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876bc33bbe48322bc9217aafbb97e24