### PR TITLE
Add file upload support and simplify start menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Use the **Stream** checkbox in the UI to receive incremental tokens. The server
 exposes a `/api/chat/stream` endpoint that streams responses using
 Server-Sent Events.
 
+## File Upload
+
+When running with **Ollama (Local)**, you can attach an image or text file in the chat UI. The file content is sent to `/api/file` and the server responds with a confirmation. Uploads are rejected when using OpenAI.
+
 ## Testing
 
 Run unit and integration tests with:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This project is a simple chat application built with React that interacts with t
    npm install
    ```
 2. Provide your OpenAI API key via the `OPENAI_API_KEY` environment variable.
-3. (Optional) Set `OLLAMA_MODEL` to change the local model used by Ollama.
+3. (Optional) Set `OLLAMA_MODEL` to change the default model used by Ollama.
 4. Start the server using `nps` to choose the LLM environment:
    ```bash
    npx nps start
    ```
-   You'll be prompted to select **Local** (to use devices via MCP), **OpenAI**, or **Ollama**.
+   You'll be prompted to select **OpenAI** or **Ollama (Local)**, then choose a model (currently only **DeepSeek R1:7b**).
 5. Open `http://localhost:3000` in your browser.
 
 ## Streaming

--- a/public/script.js
+++ b/public/script.js
@@ -11,6 +11,7 @@ function ChatApp() {
   const [messages, setMessages] = React.useState([]);
   const [useStream, setUseStream] = React.useState(false);
   const inputRef = React.useRef(null);
+  const fileRef = React.useRef(null);
 
   const addMessage = (role, text) => {
     setMessages(prev => [...prev, { role, text }]);
@@ -18,8 +19,25 @@ function ChatApp() {
 
   const sendText = async () => {
     const input = inputRef.current;
+    const fileInput = fileRef.current;
     const text = input.value.trim();
-    if (!text) return;
+    const file = fileInput.files[0];
+    if (!text && !file) return;
+    if (file) {
+      const reader = new FileReader();
+      const data = await new Promise(r => { reader.onload = () => r(reader.result); });
+      reader.readAsDataURL(file);
+      addMessage('user', file.name);
+      fileInput.value = '';
+      const res = await fetch('/api/file', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: file.name, content: data })
+      });
+      const dataRes = await res.json();
+      addMessage('assistant', dataRes.reply || dataRes.error);
+      return;
+    }
     addMessage('user', text);
     input.value = '';
     if (useStream) {
@@ -81,6 +99,7 @@ function ChatApp() {
       )
     ),
     React.createElement('div', { className: 'controls' },
+      React.createElement('input', { type: 'file', id: 'file', ref: fileRef, accept: '.txt,image/*' }),
       React.createElement('input', { id: 'input', ref: inputRef, placeholder: 'Type a message', onKeyDown }),
       React.createElement('label', null,
         React.createElement('input', {

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const app = express();
 // Use more verbose logging
 app.use(morgan('combined'));
 app.use(express.json({ limit: '2mb' }));
-const { sendMessage, sendMessageStream } = require('./openaiClient');
+const { sendMessage, sendMessageStream, getEnv } = require('./openaiClient');
 const MCP = require('./mcp');
 const mcp = new MCP();
 
@@ -48,6 +48,24 @@ app.post('/api/chat', async (req, res) => {
   } catch (err) {
     console.error('OpenAI request failed', err);
     res.status(500).json({ error: 'OpenAI request failed' });
+  }
+});
+
+app.post('/api/file', async (req, res) => {
+  const { name, content } = req.body || {};
+  if (!name || !content) {
+    console.log('POST /api/file missing file');
+    return res.status(400).json({ error: 'File is required' });
+  }
+  if (getEnv() === 'openai') {
+    return res.status(400).json({ error: 'File upload not supported in OpenAI mode' });
+  }
+  try {
+    console.log(`Received file ${name}`);
+    res.json({ reply: `Received file ${name}` });
+  } catch (err) {
+    console.error('File upload failed', err);
+    res.status(500).json({ error: 'File upload failed' });
   }
 });
 

--- a/start.js
+++ b/start.js
@@ -7,14 +7,19 @@ function ask(question) {
 }
 
 (async () => {
-  const answer = await ask('Choose environment (1) Local (2) OpenAI (3) Ollama: ');
+  const answer = await ask('Choose environment (1) OpenAI (2) Ollama (Local): ');
   let env = 'openai';
-  if (/^1|local/i.test(answer)) env = 'local';
-  else if (/^3|ollama/i.test(answer)) env = 'ollama';
+  if (/^2|ollama/i.test(answer)) env = 'ollama';
+
+  let model = process.env.OLLAMA_MODEL;
+  if (env === 'ollama') {
+    await ask('Select model (1) DeepSeek R1:7b: ');
+    model = 'deepseek-r1:7b';
+  }
 
   const child = spawn('node', ['server.js'], {
     stdio: 'inherit',
-    env: { ...process.env, LLM_ENV: env }
+    env: { ...process.env, LLM_ENV: env, OLLAMA_MODEL: model }
   });
   child.on('close', code => process.exit(code));
 })();


### PR DESCRIPTION
## Summary
- add model prompt and rename options in `start.js`
- enable streaming for all models in `openaiClient.js`
- support file uploads via `/api/file`
- update frontend to allow file input
- refresh README instructions
- adjust tests for streaming behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876cb8a27848322b8a2b94eb8994f2c