### PR TITLE
Implement shutdown button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,6 +64,11 @@
       color: #fff;
     }
 
+    #shutdown {
+      background-color: #f44336;
+      color: #fff;
+    }
+
   </style>
 </head>
 <body>

--- a/public/script.js
+++ b/public/script.js
@@ -65,6 +65,10 @@ function ChatApp() {
     }
   };
 
+  const shutdown = async () => {
+    await fetch('/api/shutdown', { method: 'POST' });
+  };
+
   const onKeyDown = e => {
     if (e.key === 'Enter') {
       e.preventDefault();
@@ -90,7 +94,12 @@ function ChatApp() {
         }),
         ' Stream'
       ),
-      React.createElement('button', { id: 'send', onClick: sendText }, 'Send')
+      React.createElement('button', { id: 'send', onClick: sendText }, 'Send'),
+      React.createElement(
+        'button',
+        { id: 'shutdown', onClick: shutdown },
+        'Shutdown'
+      )
     )
   );
 }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ app.use(express.json({ limit: '2mb' }));
 const { sendMessage, sendMessageStream } = require('./openaiClient');
 const MCP = require('./mcp');
 const mcp = new MCP();
+const { exec } = require('child_process');
 
 app.post('/api/chat/stream', async (req, res) => {
   const { message } = req.body;
@@ -66,6 +67,17 @@ app.post('/api/connect', async (req, res) => {
     console.error('Connection failed', err);
     res.status(500).json({ error: 'Connection failed' });
   }
+});
+
+app.post('/api/shutdown', (req, res) => {
+  exec('shutdown -h now', err => {
+    if (err) {
+      console.error('Shutdown failed', err);
+      return res.status(500).json({ error: 'Shutdown failed' });
+    }
+    console.log('Shutdown initiated');
+    res.json({ reply: 'Shutting down...' });
+  });
 });
 
 app.use(express.static('public'));

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -21,3 +21,12 @@ test('pressing Enter sends the message', async () => {
   await new Promise(r => setTimeout(r, 0));
   expect(fetch).toHaveBeenCalledWith('/api/chat', expect.objectContaining({ method: 'POST' }));
 });
+
+test('clicking shutdown sends request', async () => {
+  setupChat(document);
+  await new Promise(r => setTimeout(r, 0));
+  const button = document.getElementById('shutdown');
+  button.click();
+  await new Promise(r => setTimeout(r, 0));
+  expect(fetch).toHaveBeenCalledWith('/api/shutdown', expect.objectContaining({ method: 'POST' }));
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -116,5 +116,30 @@ describe('additional routes', () => {
     expect(res.body.reply).toBe('ok');
     expect(connectBluetooth).toHaveBeenCalledWith('AA:BB');
   });
+
+  it('shuts down the server host', async () => {
+    const exec = jest.fn((cmd, cb) => cb(null));
+    jest.doMock('child_process', () => ({ exec }));
+    jest.resetModules();
+    ({ setClientFactory } = require('../openaiClient'));
+    setClientFactory(() => openaiInstance);
+    app = require('../server');
+    const res = await request(app).post('/api/shutdown');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.reply).toBe('Shutting down...');
+    expect(exec).toHaveBeenCalled();
+  });
+
+  it('returns 500 when shutdown fails', async () => {
+    const exec = jest.fn((cmd, cb) => cb(new Error('fail')));
+    jest.doMock('child_process', () => ({ exec }));
+    jest.resetModules();
+    ({ setClientFactory } = require('../openaiClient'));
+    setClientFactory(() => openaiInstance);
+    app = require('../server');
+    const res = await request(app).post('/api/shutdown');
+    expect(res.statusCode).toBe(500);
+    expect(exec).toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add `/api/shutdown` server route
- style and hook a new Shutdown button in the UI
- trigger shutdown request from UI
- test server and client for new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876cde153008322a15dd4eb11647b20