### PR TITLE
Add shutdown confirmation and icon

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -113,6 +113,7 @@ function ChatApp() {
   };
 
   const shutdown = async () => {
+    if (!confirm('Are you sure…?')) return;
     await fetch('/api/shutdown', { method: 'POST' });
   };
 
@@ -143,7 +144,7 @@ function ChatApp() {
       React.createElement(
         Button,
         { id: 'shutdown', onClick: shutdown, className: 'bg-red-600 hover:bg-red-600/90' },
-        'Shutdown'
+        '\u23FB'
       )
     )
   );

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -16,6 +16,7 @@ global.TextDecoder = class {
 beforeEach(() => {
   document.body.innerHTML = `<div id="app"></div>`;
   fetch.mockClear();
+  global.confirm = jest.fn(() => true);
 });
 
 test('pressing Enter sends the message', async () => {
@@ -35,5 +36,6 @@ test('clicking shutdown sends request', async () => {
   const button = document.getElementById('shutdown');
   button.click();
   await new Promise(r => setTimeout(r, 0));
+  expect(confirm).toHaveBeenCalledWith('Are you sure\u2026?');
   expect(fetch).toHaveBeenCalledWith('/api/shutdown', expect.objectContaining({ method: 'POST' }));
 });


### PR DESCRIPTION
## Summary
- add a confirmation dialog before sending the shutdown request
- use a power icon instead of text for the shutdown button
- update tests for the new confirmation step

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a961ecb3c8322828ec855710daae4