### PR TITLE
UI update for upload

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -137,8 +137,36 @@ function ChatApp() {
         )
       )
     ),
-    React.createElement('div', { className: 'controls flex gap-2' },
-      React.createElement('input', { type: 'file', id: 'file', ref: fileRef, accept: '.txt,image/*', className: 'flex-1 border rounded-md p-2 text-sm' }),
+    React.createElement('div', { className: 'controls flex gap-2 items-center' },
+      React.createElement('input', { type: 'file', id: 'file', ref: fileRef, accept: '.txt,image/*', className: 'hidden' }),
+      React.createElement(
+        'label',
+        {
+          htmlFor: 'file',
+          className:
+            'p-2 border rounded-md bg-gray-200 hover:bg-gray-300 cursor-pointer',
+          title: 'Upload file'
+        },
+        React.createElement(
+          'svg',
+          {
+            xmlns: 'http://www.w3.org/2000/svg',
+            viewBox: '0 0 20 20',
+            fill: 'currentColor',
+            className: 'w-5 h-5'
+          },
+          [
+            React.createElement('path', {
+              key: 'p1',
+              d: 'M9.25 13.25a.75.75 0 001.5 0V4.636l2.955 3.129a.75.75 0 001.09-1.03l-4.25-4.5a.75.75 0 00-1.09 0l-4.25 4.5a.75.75 0 101.09 1.03L9.25 4.636v8.614z'
+            }),
+            React.createElement('path', {
+              key: 'p2',
+              d: 'M3.5 12.75a.75.75 0 00-1.5 0v2.5A2.75 2.75 0 004.75 18h10.5A2.75 2.75 0 0018 15.25v-2.5a.75.75 0 00-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5z'
+            })
+          ]
+        )
+      ),
       React.createElement('input', { id: 'input', ref: inputRef, placeholder: 'Type a message', onKeyDown, className: 'flex-1 border rounded-md p-2 text-sm' }),
       React.createElement(Button, { id: 'send', onClick: sendText, className: 'bg-green-600 hover:bg-green-600/90' }, 'Send'),
       React.createElement(


### PR DESCRIPTION
## Summary
- hide the native file input in the chat UI
- add a label button with an upload icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a97e995b88322a2674b9c2b059318