### PR TITLE
Add controls for clearing chat history

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -117,6 +117,15 @@ function ChatApp() {
     await fetch('/api/shutdown', { method: 'POST' });
   };
 
+  const resetConversation = () => {
+    setMessages([]);
+  };
+
+  const clearMessages = () => {
+    if (!confirm('Delete all messages?')) return;
+    setMessages([]);
+  };
+
   const onKeyDown = e => {
     if (e.key === 'Enter') {
       e.preventDefault();
@@ -141,6 +150,8 @@ function ChatApp() {
       React.createElement('input', { type: 'file', id: 'file', ref: fileRef, accept: '.txt,image/*', className: 'flex-1 border rounded-md p-2 text-sm' }),
       React.createElement('input', { id: 'input', ref: inputRef, placeholder: 'Type a message', onKeyDown, className: 'flex-1 border rounded-md p-2 text-sm' }),
       React.createElement(Button, { id: 'send', onClick: sendText, className: 'bg-green-600 hover:bg-green-600/90' }, 'Send'),
+      React.createElement(Button, { id: 'reset', onClick: resetConversation, className: 'bg-yellow-600 hover:bg-yellow-600/90' }, 'New'),
+      React.createElement(Button, { id: 'clear', onClick: clearMessages, className: 'bg-gray-600 hover:bg-gray-600/90' }, 'Clear'),
       React.createElement(
         Button,
         { id: 'shutdown', onClick: shutdown, className: 'bg-red-600 hover:bg-red-600/90' },

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -39,3 +39,32 @@ test('clicking shutdown sends request', async () => {
   expect(confirm).toHaveBeenCalledWith('Are you sure\u2026?');
   expect(fetch).toHaveBeenCalledWith('/api/shutdown', expect.objectContaining({ method: 'POST' }));
 });
+
+test('clicking reset starts a new conversation', async () => {
+  setupChat(document);
+  await new Promise(r => setTimeout(r, 0));
+  const input = document.getElementById('input');
+  input.value = 'hi';
+  document.getElementById('send').click();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.querySelectorAll('#messages .msg').length).toBeGreaterThan(0);
+  const reset = document.getElementById('reset');
+  reset.click();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.querySelectorAll('#messages .msg').length).toBe(0);
+});
+
+test('clicking clear removes messages with confirm', async () => {
+  setupChat(document);
+  await new Promise(r => setTimeout(r, 0));
+  const input = document.getElementById('input');
+  input.value = 'hi';
+  document.getElementById('send').click();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.querySelectorAll('#messages .msg').length).toBeGreaterThan(0);
+  const clear = document.getElementById('clear');
+  clear.click();
+  await new Promise(r => setTimeout(r, 0));
+  expect(confirm).toHaveBeenCalledWith('Delete all messages?');
+  expect(document.querySelectorAll('#messages .msg').length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add resetConversation and clearMessages helpers
- expose "New" and "Clear" buttons in chat controls
- test new reset and clear functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a97eaf6e0832296fd6c96accd708d