### PR TITLE
Simplify startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ This project is a simple chat application built with React that interacts with t
    npm install
    ```
 2. Provide your OpenAI API key via the `OPENAI_API_KEY` environment variable.
-3. (Optional) Set `OLLAMA_MODEL` to change the default model used by Ollama.
-4. Start the server using `nps` to choose the LLM environment:
+3. (Optional) Configure these environment variables before starting:
+   - `LLM_ENV` – set to `ollama` to use a local model (defaults to `openai`).
+   - `OLLAMA_MODEL` – override the default Ollama model.
+4. Start the server:
    ```bash
    npx nps start
    ```
-   You'll be prompted to select **OpenAI** or **Ollama (Local)**, then choose a model (currently only **DeepSeek R1:7b**).
+   This now simply spawns `server.js` using your existing environment variables with no interactive prompts.
 5. Open `http://localhost:3000` in your browser.
 
 ## Streaming

--- a/start.js
+++ b/start.js
@@ -1,25 +1,12 @@
-const readline = require('readline');
 const { spawn } = require('child_process');
 
-function ask(question) {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
-}
+// Simply start the server with whatever environment variables were provided.
+// This removes the previous interactive prompt so the caller can control
+// configuration via environment variables such as LLM_ENV and OLLAMA_MODEL.
 
-(async () => {
-  const answer = await ask('Choose environment (1) OpenAI (2) Ollama (Local): ');
-  let env = 'openai';
-  if (/^2|ollama/i.test(answer)) env = 'ollama';
+const child = spawn('node', ['server.js'], {
+  stdio: 'inherit',
+  env: process.env
+});
 
-  let model = process.env.OLLAMA_MODEL;
-  if (env === 'ollama') {
-    await ask('Select model (1) DeepSeek R1:7b: ');
-    model = 'deepseek-r1:7b';
-  }
-
-  const child = spawn('node', ['server.js'], {
-    stdio: 'inherit',
-    env: { ...process.env, LLM_ENV: env, OLLAMA_MODEL: model }
-  });
-  child.on('close', code => process.exit(code));
-})();
+child.on('close', code => process.exit(code));


### PR DESCRIPTION
## Summary
- run `server.js` without interactive prompts and keep provided env vars
- document how to start the server with custom environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa86c8f20832296bfbabb69d2a593