### PR TITLE
Add multi-tab chat support

### DIFF
--- a/test/script.test.js
+++ b/test/script.test.js
@@ -81,3 +81,16 @@ test('clicking update triggers repository pull', async () => {
   await new Promise(r => setTimeout(r, 0));
   expect(fetch).toHaveBeenCalledWith('/api/update', expect.objectContaining({ method: 'POST' }));
 });
+
+test('new tab starts with empty messages', async () => {
+  setupChat(document);
+  await new Promise(r => setTimeout(r, 0));
+  const input = document.getElementById('input');
+  input.value = 'hi';
+  document.getElementById('send').click();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.querySelectorAll('#messages .msg').length).toBeGreaterThan(0);
+  document.getElementById('add-tab').click();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.querySelectorAll('#messages .msg').length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- enable multiple chat tabs in the front-end
- keep separate messages and model per tab
- show tabs UI with add/remove actions
- adapt tests for new tab behaviour

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687aaeb947788322a5140f55e2db107c