### PR TITLE
Update provider selection and default models

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ This project is a simple chat application built with React that interacts with t
    npm install
    ```
 2. Provide your OpenAI API key via the `OPENAI_API_KEY` environment variable.
-3. (Optional) Configure these environment variables before starting:
-   - `LLM_ENV` – set to `openai` to use OpenAI instead of Ollama (defaults to `ollama`).
-   - `OLLAMA_MODEL` – override the default Ollama model.
+3. (Optional) Set `LLM_ENV` to `openai` or `ollama` before starting to choose the default provider.
 4. Start the server:
    ```bash
    npm start
    ```
    The server starts immediately using the environment variables you set.
 5. Open `http://localhost:3000` in your browser.
-6. Choose `OpenAI` or `Ollama` in the environment drop-down. When selected, available models are fetched automatically and you must pick one before sending messages.
+6. Open the chat UI and pick `OpenAI` or `Ollama` in the provider drop-down before sending any message. The input box and Send button remain disabled until a provider is chosen.
+   - `OpenAI` always uses the inexpensive `gpt-3.5-turbo` model.
+   - `Ollama` always uses the `deepseek-r1:8b` model.
 
 ## Streaming
 

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ function isLocal(req) {
 }
 
 app.post('/api/chat/stream', async (req, res) => {
-  const { message, env, model } = req.body;
+  const { message, env } = req.body;
   if (!message) {
     console.log('POST /api/chat/stream missing message');
     return res.status(400).json({ error: 'Message is required' });
@@ -31,7 +31,7 @@ app.post('/api/chat/stream', async (req, res) => {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.flushHeaders();
-    for await (const chunk of sendMessageStream(message, [], { env, model })) {
+    for await (const chunk of sendMessageStream(message, [], { env })) {
       res.write(`data: ${chunk}\n\n`);
     }
     res.write('data: [DONE]\n\n');
@@ -43,14 +43,14 @@ app.post('/api/chat/stream', async (req, res) => {
 });
 
 app.post('/api/chat', async (req, res) => {
-  const { message, env, model } = req.body;
+  const { message, env } = req.body;
   if (!message) {
     console.log('POST /api/chat missing message');
     return res.status(400).json({ error: 'Message is required' });
   }
   try {
     console.log(`POST /api/chat: ${message}`);
-    const reply = await sendMessage(message, [], { env, model });
+    const reply = await sendMessage(message, [], { env });
     console.log(`reply: ${reply}`);
     res.json({ reply });
   } catch (err) {

--- a/test/openaiClient.test.js
+++ b/test/openaiClient.test.js
@@ -37,6 +37,11 @@ test('sendMessage returns text from openai', async () => {
   }
   createMock.mockResolvedValueOnce(gen());
   const reply = await sendMessage('hi', [], { env: 'openai' });
+  expect(createMock).toHaveBeenCalledWith({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: 'hi' }],
+    stream: true
+  });
   expect(reply).toBe('unit reply');
 });
 
@@ -69,6 +74,11 @@ test('sendMessageStream yields tokens', async () => {
   for await (const p of sendMessageStream('hi', [], { env: 'openai' })) {
     parts.push(p);
   }
+  expect(createMock).toHaveBeenCalledWith({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: 'hi' }],
+    stream: true
+  });
   expect(parts.join('')).toBe('hello');
 });
 
@@ -93,6 +103,7 @@ test('sendMessage uses Ollama when env is ollama', async () => {
   const reply = await sendMessage('hi', [], { env: 'ollama' });
   expect(postMock).toHaveBeenCalled();
   expect(postMock.mock.calls[0][0]).toBe('http://localhost:11434/api/chat');
+  expect(postMock.mock.calls[0][1].model).toBe('deepseek-r1:8b');
   expect(postMock.mock.calls[0][1].tools).toBeDefined();
   expect(postMock.mock.calls[0][1].tools.find(t => t.function.name === 'search_web')).toBeTruthy();
   expect(reply).toBe('hey');
@@ -105,6 +116,7 @@ test('sendMessageStream uses Ollama when env is ollama', async () => {
     parts.push(p);
   }
   expect(postMock).toHaveBeenCalled();
+  expect(postMock.mock.calls[0][1].model).toBe('deepseek-r1:8b');
   expect(postMock.mock.calls[0][1].tools.find(t => t.function.name === 'search_web')).toBeTruthy();
   expect(parts.join('')).toBe('hello');
 });

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -3,7 +3,6 @@ const { setupChat } = require('../public/script');
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
-    json: () => Promise.resolve({ models: ['m1'] }),
     body: { getReader: () => ({ read: () => Promise.resolve({ done: true }) }) }
   })
 );
@@ -18,19 +17,14 @@ beforeEach(() => {
 
 const flush = () => new Promise(r => setTimeout(r,0));
 
-test('default env is ollama', async () => {
+test('input disabled until provider selected', async () => {
   setupChat(document);
   await flush();
-  expect(document.getElementById('env').value).toBe('ollama');
-});
-
-
-test('model list failure leaves only placeholder', async () => {
-  fetch.mockResolvedValueOnce({ json: () => Promise.reject(new Error('fail')) });
-  setupChat(document);
+  const env = document.getElementById('env');
+  expect(env.value).toBe('');
+  expect(document.getElementById('input').disabled).toBe(true);
+  env.value = 'openai';
+  env.dispatchEvent(new Event('change', { bubbles: true }));
   await flush();
-  document.getElementById('env').dispatchEvent(new Event('change', { bubbles: true }));
-  await flush();
-  await flush();
-  expect(document.getElementById('model').options.length).toBeGreaterThanOrEqual(1);
+  expect(document.getElementById('input').disabled).toBe(false);
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -157,19 +157,13 @@ describe('GET /api/models', () => {
     app = require('../server');
   });
 
-  it('lists models for openai', async () => {
-    const list = jest.fn().mockResolvedValue({ data: [{ id: 'a' }] });
-    openaiInstance.models = { list };
-    const res = await request(app).get('/api/models').query({ env: 'openai' });
-    expect(res.statusCode).toBe(200);
-    expect(res.body.models).toContain('a');
-  });
-
-  it('handles errors', async () => {
-    const list = jest.fn().mockRejectedValue(new Error('fail'));
-    openaiInstance.models = { list };
-    const res = await request(app).get('/api/models').query({ env: 'openai' });
-    expect(res.statusCode).toBe(500);
+  it('returns default models for each provider', async () => {
+    const resOpen = await request(app).get('/api/models').query({ env: 'openai' });
+    expect(resOpen.statusCode).toBe(200);
+    expect(resOpen.body.models).toContain('gpt-3.5-turbo');
+    const resOllama = await request(app).get('/api/models').query({ env: 'ollama' });
+    expect(resOllama.statusCode).toBe(200);
+    expect(resOllama.body.models).toContain('deepseek-r1:8b');
   });
 });
 


### PR DESCRIPTION
## Summary
- drop model selection from the frontend
- provider dropdown now required before chatting
- always use `deepseek-r1:8b` for Ollama and `gpt-3.5-turbo` for OpenAI
- simplify model listing API
- update tests for new behaviour and add model assertions
- document provider selection and fixed models in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac26f76048322b5ea5e0e29b2bd81