### PR TITLE
Improve Ollama error handling

### DIFF
--- a/test/openaiClient.test.js
+++ b/test/openaiClient.test.js
@@ -24,6 +24,7 @@ let sendMessage, sendMessageStream, setClientFactory;
 
 beforeEach(() => {
   jest.resetModules();
+  process.env.OLLAMA_MODEL = 'deepseek-r1:8b';
   axios = require('axios');
   postMock = axios.post;
   ({ sendMessage, sendMessageStream, setClientFactory } = require('../openaiClient'));


### PR DESCRIPTION
## Summary
- let `OLLAMA_MODEL` override the default model
- surface Ollama error messages back to the caller
- update tests to set `OLLAMA_MODEL`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687acdcbcb1c8322b343724581d827c4