### PR TITLE
Add Ollama generate/show endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,12 @@ functions. Two example tools are provided:
 Use the gear icon in the top right to access **Update** and **Shutdown** actions. The **Update** option triggers `/api/update` and performs a `git pull` so you can update the repository from the browser.
 
 The Ollama backend uses the official Jinja template from the `deepseek-r1-tool-calling` repository to format prompts. Tool responses are parsed and executed server-side before the final reply is generated.
+
+## Additional Ollama Endpoints
+
+Two helper routes are exposed for accessing the Ollama API directly:
+
+- `POST /api/generate` – wraps Ollama's [`/api/generate` endpoint](https://raw.githubusercontent.com/ollama/ollama/main/docs/api.md) to return a single completion for a prompt. Pass `{ "prompt": "text", "env": "ollama" }` and the server will respond with `{ "reply": "..." }`.
+- `POST /api/show` – calls Ollama's [`/api/show` endpoint](https://raw.githubusercontent.com/ollama/ollama/main/docs/api.md) and returns the model metadata. Provide `{ "model": "name" }` to receive `{ "info": {...} }`.
+
+These routes require `env: "ollama"` and are useful for inspecting models or generating standalone completions.

--- a/openaiClient.js
+++ b/openaiClient.js
@@ -269,4 +269,47 @@ async function listModels(targetEnv) {
   return model ? [model] : [];
 }
 
-module.exports = { sendMessage, sendMessageStream, setEnv, setClientFactory, getEnv, chatWithOllamaTools, listModels };
+async function generateCompletion(prompt, options = {}) {
+  if (options.env !== 'ollama') {
+    throw new Error('generateCompletion only supports ollama');
+  }
+  try {
+    const res = await axios.post('http://localhost:11434/api/generate', {
+      model: getModelForEnv('ollama'),
+      prompt,
+      stream: false,
+      template: OLLAMA_TEMPLATE
+    });
+    return res.data.response || '';
+  } catch (err) {
+    const msg = err.response?.data?.error || err.message;
+    throw new Error(`Ollama generate failed: ${msg}`);
+  }
+}
+
+async function showModel(model, options = {}) {
+  if ((options.env && options.env !== 'ollama')) {
+    throw new Error('showModel only supports ollama');
+  }
+  try {
+    const res = await axios.post('http://localhost:11434/api/show', {
+      model: model || getModelForEnv('ollama')
+    });
+    return res.data;
+  } catch (err) {
+    const msg = err.response?.data?.error || err.message;
+    throw new Error(`Ollama show failed: ${msg}`);
+  }
+}
+
+module.exports = {
+  sendMessage,
+  sendMessageStream,
+  setEnv,
+  setClientFactory,
+  getEnv,
+  chatWithOllamaTools,
+  listModels,
+  generateCompletion,
+  showModel
+};

--- a/test/openaiClient.test.js
+++ b/test/openaiClient.test.js
@@ -143,3 +143,22 @@ test('openai tool calls are executed', async () => {
   expect(toolMsg).toBeTruthy();
 });
 
+test('generateCompletion uses ollama generate endpoint', async () => {
+  postMock.mockResolvedValueOnce({ data: { response: 'hello' } });
+  const { generateCompletion } = require('../openaiClient');
+  const res = await generateCompletion('hi', { env: 'ollama' });
+  expect(postMock).toHaveBeenCalledWith(
+    'http://localhost:11434/api/generate',
+    expect.objectContaining({ model: 'MFDoom/deepseek-r1-tool-calling:8b', prompt: 'hi', stream: false })
+  );
+  expect(res).toBe('hello');
+});
+
+test('showModel fetches model info', async () => {
+  postMock.mockResolvedValueOnce({ data: { modelfile: 'abc' } });
+  const { showModel } = require('../openaiClient');
+  const info = await showModel('m1', { env: 'ollama' });
+  expect(postMock).toHaveBeenCalledWith('http://localhost:11434/api/show', { model: 'm1' });
+  expect(info.modelfile).toBe('abc');
+});
+

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -170,3 +170,31 @@ describe('GET /api/models', () => {
   });
 });
 
+describe('new ollama routes', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ({ setEnv, setClientFactory } = require('../openaiClient'));
+    setEnv('ollama');
+    setClientFactory(() => openaiInstance);
+    app = require('../server');
+  });
+
+  it('returns generate completion', async () => {
+    const axios = require('axios');
+    axios.post = jest.fn().mockResolvedValueOnce({ data: { response: 'hi' } });
+    const res = await request(app).post('/api/generate').send({ prompt: 'hi', env: 'ollama' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.reply).toBe('hi');
+    expect(axios.post).toHaveBeenCalled();
+  });
+
+  it('shows model info', async () => {
+    const axios = require('axios');
+    axios.post = jest.fn().mockResolvedValueOnce({ data: { modelfile: 'abc' } });
+    const res = await request(app).post('/api/show').send({ model: 'm1' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.info.modelfile).toBe('abc');
+    expect(axios.post).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `generateCompletion` and `showModel` helpers
- expose `/api/generate` and `/api/show` routes
- document new endpoints in README
- test ollama generate/show helpers and routes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ad5f1123c832285caa191ae261391