### PR TITLE
Fix tool call chaining and enable Send button

### DIFF
--- a/openaiClient.js
+++ b/openaiClient.js
@@ -152,7 +152,7 @@ async function executeToolCalls(provider, currentMessages, msg, model) {
       toolOutputs.push({ role: 'tool', content: JSON.stringify({ error: `Function ${call.function.name} not implemented` }), tool_call_id: call.id });
     }
   }
-  currentMessages.push(...toolOutputs);
+  currentMessages.push(msg, ...toolOutputs);
   if (provider === 'ollama') {
     const final = await axios.post('http://localhost:11434/api/chat', {
       model,

--- a/public/script.js
+++ b/public/script.js
@@ -275,8 +275,8 @@ function ChatApp() {
         React.createElement('option', { key: 'ollama', value: 'ollama' }, 'Ollama'),
         React.createElement('option', { key: 'openai', value: 'openai' }, 'OpenAI')
       ]),
-      React.createElement('input', { id: 'input', ref: inputRef, placeholder: 'Type a message', onKeyDown, className: 'flex-1 border rounded-md p-2 text-sm', disabled: true }),
-      React.createElement(Button, { id: 'send', onClick: sendText, className: 'bg-green-600 hover:bg-green-600/90', disabled: true }, 'Send'),
+      React.createElement('input', { id: 'input', ref: inputRef, placeholder: 'Type a message', onKeyDown, className: 'flex-1 border rounded-md p-2 text-sm', disabled: !currentTab.env }),
+      React.createElement(Button, { id: 'send', onClick: sendText, className: 'bg-green-600 hover:bg-green-600/90', disabled: !currentTab.env }, 'Send'),
       showMenu && React.createElement('div', { className: 'absolute right-0 top-10 bg-white border rounded shadow p-2 space-y-1' }, [
         React.createElement('button', { key: 'update', onClick: updateAssistant, className: 'block w-full text-left px-2 py-1 hover:bg-gray-100' }, 'Update'),
         React.createElement('button', { key: 'shutdown', onClick: shutdown, className: 'block w-full text-left px-2 py-1 hover:bg-gray-100' }, 'Shutdown')


### PR DESCRIPTION
## Summary
- include assistant message when chaining tool calls to OpenAI
- enable chat input and Send button based on selected provider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b87de50c4832290da63c84eaf3519