### PR TITLE
Remove weather and email tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ The application talks to Ollama at `http://localhost:11434/api`. If you need to 
 
 ## Tool Calling
 
-Requests to Ollama always include `stream: true`. Tool calls follow this flow:
+Requests to Ollama always include `stream: true`. When a model decides to call a
+tool, the flow looks like this:
 
 1. User message is sent:
    ```json
-   { "role": "user", "content": "What is the weather in Warsaw?" }
+   { "role": "user", "content": "Hello" }
    ```
-2. Ollama responds with tool calls:
+2. Ollama may respond with tool calls:
    ```json
    {
      "role": "assistant",
@@ -39,21 +40,18 @@ Requests to Ollama always include `stream: true`. Tool calls follow this flow:
        {
          "id": "toolcall-abc123",
          "type": "function",
-         "function": {
-           "name": "getWeather",
-           "arguments": "{\"location\": \"Warsaw\"}"
-         }
+         "function": { "name": "someFunction", "arguments": "{}" }
        }
      ]
    }
    ```
-3. The application invokes the tool and replies using the same `tool_call_id`:
+3. The application executes the tool locally and replies using the same `tool_call_id`:
    ```json
    {
      "role": "tool",
      "tool_call_id": "toolcall-abc123",
-     "name": "getWeather",
-     "content": "{\"temperature\": \"22C\", \"condition\": \"cloudy\"}"
+     "name": "someFunction",
+     "content": "{\"result\":true}"
    }
    ```
 4. Ollama returns the final assistant message which is streamed to the UI.

--- a/ollamaClient.js
+++ b/ollamaClient.js
@@ -6,51 +6,9 @@ const BASE = process.env.OLLAMA_BASE || 'http://localhost:11434';
 
 const systemPrompt = 'You are a helpful assistant.';
 
-const tools = [
-  {
-    type: 'function',
-    function: {
-      name: 'get_current_weather',
-      description: 'Get current weather for a location.',
-      parameters: {
-        type: 'object',
-        properties: {
-          location: { type: 'string', description: 'City name.' },
-          unit: { type: 'string', enum: ['celsius', 'fahrenheit'], description: 'Temperature unit.' }
-        },
-        required: ['location']
-      }
-    }
-  },
-  {
-    type: 'function',
-    function: {
-      name: 'send_email',
-      description: 'Send an email to a recipient.',
-      parameters: {
-        type: 'object',
-        properties: {
-          to: { type: 'string', description: 'Recipient address.' },
-          subject: { type: 'string', description: 'Email subject.' },
-          body: { type: 'string', description: 'Email body.' }
-        },
-        required: ['to', 'subject', 'body']
-      }
-    }
-  }
-];
+const tools = [];
 
-const availableFunctions = {
-  get_current_weather: async (location, unit = 'celsius') => {
-    const data = {
-      Warsaw: { temperature: '22C', condition: 'cloudy' }
-    };
-    return data[location] || { error: 'unknown location' };
-  },
-  send_email: async (to, subject, body) => {
-    return { status: 'sent', to, subject };
-  }
-};
+const availableFunctions = {};
 
 async function readStream(res) {
   let buffer = '';

--- a/test/ollamaClient.test.js
+++ b/test/ollamaClient.test.js
@@ -13,17 +13,6 @@ afterEach(() => {
   axios.post.mockReset();
 });
 
-test('tool calling flow', async () => {
-  axios.post
-    .mockResolvedValueOnce(streamFor([JSON.stringify({ message: { tool_calls: [{ id: '1', type: 'function', function: { name: 'send_email', arguments: '{"to":"a","subject":"s","body":"b"}' } }] } }), JSON.stringify({ done: true })]))
-    .mockResolvedValueOnce(streamFor([JSON.stringify({ message: { content: 'done' } }), JSON.stringify({ done: true })]));
-  const { sendMessage } = require('../ollamaClient');
-  const reply = await sendMessage('hi', [], { env: 'ollama' });
-  expect(reply).toBe('done');
-  expect(axios.post).toHaveBeenCalledTimes(2);
-  expect(axios.post.mock.calls[0][1].stream).toBe(true);
-  expect(axios.post.mock.calls[1][1].stream).toBe(true);
-});
 
 test('sendMessageStream yields content', async () => {
   axios.post.mockResolvedValueOnce(streamFor([JSON.stringify({ message: { content: 'hello' } }), JSON.stringify({ done: true })]));


### PR DESCRIPTION
## Summary
- drop unused get_current_weather and send_email helpers
- simplify `toolChat.js` to stream chat without tools
- clean up tool definitions from `ollamaClient.js`
- update README tool calling docs
- adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b9dac6f608322b15c8723bc520d3c