### PR TITLE
Add stream parser client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.8",
+        "eventsource-parser": "^3.0.3",
         "express": "^5.1.0",
         "morgan": "^1.10.0",
         "react": "^18.2.0",
@@ -2676,6 +2677,15 @@
         "split": "0.3",
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "axios": "^1.6.8",
+    "eventsource-parser": "^3.0.3",
     "express": "^5.1.0",
     "morgan": "^1.10.0",
-    "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/sseClient.js
+++ b/sseClient.js
@@ -1,0 +1,56 @@
+// Streaming chat client using fetch and eventsource-parser
+// Sends a request to Ollama's /api/chat endpoint and prints streamed output
+
+const { createParser } = require('eventsource-parser');
+
+/**
+ * Stream chat completion from Ollama.
+ * @param {Array} messages - Chat history formatted for /api/chat.
+ * @param {string} model - Model name, defaults to environment variable or unspecified.
+ */
+async function streamChat(messages, model) {
+  const body = {
+    stream: true,
+    messages,
+  };
+  if (model) body.model = model;
+
+  // Send POST request using fetch
+  const response = await fetch('http://localhost:11434/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+
+  // Set up SSE parser
+  const parser = createParser(event => {
+    if (event.type !== 'event') return; // ignore other events
+    if (!event.data) return; // skip empty events
+    if (event.data === '[DONE]') {
+      console.log('\n[complete]');
+      return;
+    }
+    const payload = JSON.parse(event.data);
+    const delta = payload.delta || payload.message || {};
+    if (delta.content) process.stdout.write(delta.content);
+  });
+
+  const decoder = new TextDecoder();
+
+  // Read and decode the stream chunk by chunk
+  for await (const chunk of response.body) {
+    parser.feed(decoder.decode(chunk));
+  }
+}
+
+// Example usage when run directly
+if (require.main === module) {
+  const prompt = process.argv.slice(2).join(' ') || 'Hello';
+  streamChat([{ role: 'user', content: prompt }]).catch(err => console.error(err));
+}
+
+module.exports = { streamChat };


### PR DESCRIPTION
## Summary
- add `eventsource-parser` to dependencies
- implement `sseClient.js` example that streams chat results from Ollama

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ba91a379083229e7c3654dfb268f4